### PR TITLE
querry clock with start and end

### DIFF
--- a/back-end/lib/working_time_manager/Utils/DateTimeHelper.ex
+++ b/back-end/lib/working_time_manager/Utils/DateTimeHelper.ex
@@ -1,7 +1,7 @@
 defmodule WorkingTimeManager.Utils.DateTimeHelper do
     
     def format(dateTime) do
-        str = DateTime.to_string(dateTime)
+        str = NaiveDateTime.to_string(dateTime)
         String.slice(str, 0..-2)
     end
 

--- a/back-end/lib/working_time_manager_web/controllers/clock_controller.ex
+++ b/back-end/lib/working_time_manager_web/controllers/clock_controller.ex
@@ -8,27 +8,51 @@ defmodule WorkingTimeManagerWeb.ClockController do
   alias WorkingTimeManager.Repo
   alias WorkingTimeManager.Resource
   alias WorkingTimeManager.Resource.Clock
+  alias WorkingTimeManager.Utils.DateTimeHelper 
 
   action_fallback WorkingTimeManagerWeb.FallbackController
 
   def getclock(conn, %{"user" => user}) do
-    clock = from(c in Clock, where: c.user == ^user, order_by: [desc: c.date], limit: 1)
-      |> Repo.one()
-    if clock != nil do
-      render(conn, "show.json", clock: clock)
+    params = conn.query_params
+    if not Map.has_key?(params, "start") and not Map.has_key?(params, "end") do
+        clock = from(c in Clock, where: c.user == ^user, order_by: [desc: c.date], limit: 1)
+        |> Repo.one()
+      if clock != nil do
+        render(conn, "show.json", clock: clock)
+      else
+        send_resp(conn, :ok, "No content")
+      end
     else
-      send_resp(conn, :ok, "No content")
+      end_date   = DateTimeHelper.parse(params["end"])
+      start_date = DateTimeHelper.parse(params["start"])
+      clocks = from(c in Clock, where: c.user == ^user and c.date >= ^start_date and c.date <= ^end_date, order_by: [desc: c.date])
+        |> Repo.all()
+      if clocks != nil do
+        render(conn, "index.json", clocks: clocks)
+      else
+        send_resp(conn, :ok, "No content")
+      end
     end
   end
 
-  def clock(conn, %{"user" => useridstring}) do
-    {userid, _} = Integer.parse(useridstring)
-    last_clock = from(c in Clock, where: c.user == ^userid, order_by: [desc: c.date], limit: 1)
-      |> Repo.one()
-    clock_params = %{
-      "status" => last_clock == nil || last_clock.status == false,
-      "user" => userid,
-      "date" => DateTime.utc_now()}
+  def clock(conn, %{"user" => userid_string} = params) do
+    {userid, _} = Integer.parse(userid_string)
+    clock_params =
+    if false == Map.has_key?(params, "date") or false == Map.has_key?(params, "status") do
+      last_clock = from(c in Clock, where: c.user == ^userid, order_by: [desc: c.date], limit: 1)
+        |> Repo.one()
+      %{
+        "status" => last_clock == nil || last_clock.status == false,
+        "user" => userid,
+        "date" => DateTime.utc_now()
+      }
+    else
+      %{
+        "status" => params["status"],
+        "user" => userid,
+        "date" => DateTimeHelper.parse(params["date"])
+      }
+    end
     with {:ok, %Clock{} = clock} <- Resource.create_clock(clock_params) do
       conn
       |> put_status(:created)

--- a/back-end/lib/working_time_manager_web/views/clock_view.ex
+++ b/back-end/lib/working_time_manager_web/views/clock_view.ex
@@ -12,7 +12,7 @@ defmodule WorkingTimeManagerWeb.ClockView do
 
   def render("clock.json", %{clock: clock}) do
     %{id: clock.id,
-      date: clock.date,
+      date: WorkingTimeManager.Utils.DateTimeHelper.format(clock.date),
       status: clock.status,
       user: clock.user}
   end


### PR DESCRIPTION
- vous pouvez toujours clock sans le body et ca prendra une date sur le serveur (pb elle est en UTC a voir si ca pose un soucis)
- vous pouvez maintenant clock avec un body (pas encore de verif manager / user...): POST http://localhost:4000/api/clocks/1
body: {
    "date": "2019-09-24 09:40:2",
    "status": true
}
- vous pouvez maintenant GET une liste de clocks:
GET http://localhost:4000/api/clocks/1?start=2019-09-24%2000%3A00%3A00&end=2019-09-24%2009%3A39%3A00
retourne les clocks de aujourd'hui avant 09h39
- le http://localhost:4000/api/clocks/1 retourne toujours la derniere clock
